### PR TITLE
Change unpacker type to more specific TarGz

### DIFF
--- a/main.go
+++ b/main.go
@@ -272,15 +272,8 @@ func fixPermissions(root string) error {
 }
 
 func downloadAndInstall(dl *GoDownload) error {
-	unpacker, err := archiver.ByExtension(dl.Filename)
-	if err != nil {
-		return fmt.Errorf("don't know how to unpack %s: %v", dl.Filename, err)
-	}
 	// *archiver.TarGz is the archiver (and Unarchiver) type for the linux and macOS tarballs.
-	TarGzArchiver, ok := unpacker.(*archiver.TarGz)
-	if !ok {
-		return fmt.Errorf("The archiver type specified by source filename is not of type (*archiver.TarGz). Filename: %s specifies (%T)", dl.Filename, unpacker)
-	}
+	TarGzArchiver := archiver.NewTarGz()
 	TarGzArchiver.OverwriteExisting = true
 
 	tmpfile, shasum, err := downloadFile(dl)


### PR DESCRIPTION
Issue: #3 

As far as I can see this archiver type is used for both linux and macOS (The currently supported platforms). I guess some more branching would be needed for future windows support. I'm not sure if this is the best implementation.

Perhaps as this is now a hard type cast to a TarGz, there is no need for any of
```go
unpacker, err := archiver.ByExtension(dl.Filename)
if err != nil {
	return fmt.Errorf("don't know how to unpack %s: %v", dl.Filename, err)
}
// *archiver.TarGz is the archiver (and Unarchiver) type for the linux and macOS tarballs.
TarGzArchiver, ok := unpacker.(*archiver.TarGz)
if !ok {
	return fmt.Errorf("The archiver type specified by source filename is not of type (*archiver.TarGz). Filename: %s specifies (%T)", dl.Filename, unpacker)
}
TarGzArchiver.OverwriteExisting = true
```

and instead just have

```go
// *archiver.TarGz is the archiver (and Unarchiver) type for the linux and macOS tarballs.
TarGzArchiver := archiver.NewTarGz()
TarGzArchiver.OverwriteExisting = true
```

This would be the hard coded way and could work because as far as I can see this would still support the two currently supported operating systems.