### PR TITLE
Added gocache to the directories needed to change.

### DIFF
--- a/main.go
+++ b/main.go
@@ -299,23 +299,30 @@ func downloadAndInstall(dl *GoDownload) error {
 			return fmt.Errorf("can't rename %s to %s: %v", godir, bakgo, err)
 		}
 	}
-	err = u.Unarchive(tmpfile, *destGoDir)
-	if err != nil {
+	gocachedir := filepath.Join(*destGoDir, "gocache")
+	bakgocache := filepath.Join(*destGoDir, "gocache.bak")
+	if _, err = os.Stat(gocachedir); !os.IsNotExist(err) {
+		err = os.Rename(gocachedir, bakgocache)
+		if err != nil {
+			return fmt.Errorf("can't rename %s to %s: %v", gocachedir, bakgocache, err)
+		}
+	}
+	if err = u.Unarchive(tmpfile, *destGoDir); err != nil {
 		return fmt.Errorf("can't unpack %s to %s: %v", tmpfile, godir, err)
 	}
 	if _, err = os.Stat(godir); err != nil {
 		return fmt.Errorf("problem unpacking to %s, old go version is in %s", godir, bakgo)
 	}
-	err = os.Remove(tmpfile)
-	if err != nil {
+	if err = os.Remove(tmpfile); err != nil {
 		fmt.Fprintf(os.Stderr, "couldn't remove temporary file %s: %v", tmpfile, err)
 	}
-	err = os.RemoveAll(bakgo)
-	if err != nil {
+	if err = os.RemoveAll(bakgo); err != nil {
 		fmt.Fprintf(os.Stderr, "couldn't remove old Go version in %s: %v", bakgo, err)
 	}
-	err = fixPermissions(godir)
-	if err != nil {
+	if err = os.RemoveAll(bakgocache); err != nil {
+		fmt.Fprintf(os.Stderr, "couldn't remove old Go cache version in %s: %v", bakgocache, err)
+	}
+	if err = fixPermissions(godir); err != nil {
 		return fmt.Errorf("error installing: %v", err)
 	}
 	fmt.Println("Go upgraded successfully")

--- a/main.go
+++ b/main.go
@@ -313,14 +313,23 @@ func downloadAndInstall(dl *GoDownload) error {
 	if _, err = os.Stat(godir); err != nil {
 		return fmt.Errorf("problem unpacking to %s, old go version is in %s", godir, bakgo)
 	}
+	// If the gocache directory exists in the go install folder.
+	if _, err = os.Stat(gocachedir); !os.IsNotExist(err) {
+		if _, err = os.Stat(gocachedir); err != nil {
+			return fmt.Errorf("problem unpacking to %s, old go cache version is in %s", gocachedir, bakgocache)
+		}
+	}
 	if err = os.Remove(tmpfile); err != nil {
 		fmt.Fprintf(os.Stderr, "couldn't remove temporary file %s: %v", tmpfile, err)
 	}
 	if err = os.RemoveAll(bakgo); err != nil {
 		fmt.Fprintf(os.Stderr, "couldn't remove old Go version in %s: %v", bakgo, err)
 	}
-	if err = os.RemoveAll(bakgocache); err != nil {
-		fmt.Fprintf(os.Stderr, "couldn't remove old Go cache version in %s: %v", bakgocache, err)
+	// If the bakgocache directory exists in the go install folder.
+	if _, err = os.Stat(bakgocache); !os.IsNotExist(err) {
+		if err = os.RemoveAll(bakgocache); err != nil {
+			fmt.Fprintf(os.Stderr, "couldn't remove old Go cache version in %s: %v", bakgocache, err)
+		}
 	}
 	if err = fixPermissions(godir); err != nil {
 		return fmt.Errorf("error installing: %v", err)


### PR DESCRIPTION
Yes I also saw the os.IsExist was the problem. However you also need to do the same to the gocache directory. There is also a tmp directory but it is empty.

Since there is now 2 very similar bits of code they could be extracted into a function but overall I think the two separate statements are actually clearer and make less lines. Perhaps if there were 3 or more such similar statements then it would be better to use:

```go
renameGoFolder := func(goFolder string) (string, error) {
	bakgoFolder := goFolder + ".bak"
	if _, err = os.Stat(goFolder); !os.IsNotExist(err) {
		if err = os.Rename(goFolder, bakgoFolder); err != nil {
			return "", fmt.Errorf("can't rename %s to %s: %v", goFolder, bakgoFolder, err)
		}
	}

	return bakgoFolder, nil
}
goDir := filepath.Join(*destGoDir, "go")
bakgo, err := renameGoFolder(goDir)
if err != nil {
	return err
}
gocacheDir := filepath.Join(*destGoDir, "gocache")
bakgocache, err := renameGoFolder(gocacheDir)
if err != nil {
	return err
}
```