### PR TITLE
Use existing archiver function

### DIFF
--- a/main.go
+++ b/main.go
@@ -275,14 +275,6 @@ func fixPermissions(root string) error {
 }
 
 func downloadAndInstall(dl *GoDownload) error {
-	unpacker, err := archiver.ByExtension(dl.Filename)
-	if err != nil {
-		return fmt.Errorf("don't know how to unpack %s: %v", dl.Filename, err)
-	}
-	u, ok := unpacker.(archiver.Unarchiver)
-	if !ok {
-		return fmt.Errorf("format specified by source filename is not an archive format: %s (%T)", dl.Filename, unpacker)
-	}
 	tmpfile, shasum, err := downloadFile(dl)
 	if err != nil {
 		return fmt.Errorf("download failed: %v", err)
@@ -305,7 +297,7 @@ func downloadAndInstall(dl *GoDownload) error {
 			return fmt.Errorf("couldn't remove gocache version in %s: %v", gocachedir, err)
 		}
 	}
-	if err = u.Unarchive(tmpfile, *destGoDir); err != nil {
+	if err = archiver.Unarchive(tmpfile, *destGoDir); err != nil {
 		return fmt.Errorf("can't unpack %s to %s: %v", tmpfile, godir, err)
 	}
 	if _, err = os.Stat(godir); err != nil {


### PR DESCRIPTION
I noticed that the unarchiving steps which are below are the same as in an already existing function in the archiver library so perhaps it is better to use that function instead repeating the same code.

```go
unpacker, err := archiver.ByExtension(dl.Filename)
	if err != nil {
		return fmt.Errorf("don't know how to unpack %s: %v", dl.Filename, err)
	}
	u, ok := unpacker.(archiver.Unarchiver)
	if !ok {
		return fmt.Errorf("format specified by source filename is not an archive format: %s (%T)", dl.Filename, unpacker)
	}
if err = u.Unarchive(tmpfile, *destGoDir); err != nil {
```
from the archiver libary:
```go
func Unarchive(source, destination string) error {
	uaIface, err := ByExtension(source)
	if err != nil {
		return err
	}
	u, ok := uaIface.(Unarchiver)
	if !ok {
		return fmt.Errorf("format specified by source filename is not an archive format: %s (%T)", source, uaIface)
	}
	return u.Unarchive(source, destination)
}
```